### PR TITLE
Prototype pollution fix - checking magic attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class CacheBase extends Emitter {
    */
 
   set(key, ...rest) {
-    if (key.split(".").some((k) => isPrototypePolluted(k))) return this;
+    if (String(key).split(".").some((k) => isPrototypePolluted(k))) return this;
     if (isObject(key) || (rest.length === 0 && Array.isArray(key))) {
       return this.visit('set', key, ...rest);
     }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ const del = require('unset-value');
 const get = require('get-value');
 const set = require('set-value');
 
+
+/**
+ * Blacklist certain keys to prevent
+ * Prototype Pollution.
+ * @param {string} key 
+ */
+function isPrototypePolluted(key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key);
+}
+
+
 /**
  * Create an instance of `CacheBase`.
  *
@@ -63,6 +74,7 @@ class CacheBase extends Emitter {
    */
 
   set(key, ...rest) {
+    if (key.split(".").some((k) => isPrototypePolluted(k))) return this;
     if (isObject(key) || (rest.length === 0 && Array.isArray(key))) {
       return this.visit('set', key, ...rest);
     }

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class CacheBase extends Emitter {
    */
 
   set(key, ...rest) {
-    if (String(key).split(".").some((k) => isPrototypePolluted(k))) return this;
+    if (isString(key) && key.split(".").some((k) => isPrototypePolluted(k))) return this;
     if (isObject(key) || (rest.length === 0 && Array.isArray(key))) {
       return this.visit('set', key, ...rest);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -332,4 +332,13 @@ describe('cache-base', function() {
       assert.equal(app.size, 3);
     });
   });
+
+  describe('prototypepollution', function() {
+    it('prevent prototype pollution', function() {
+      app.set('__proto__.polluted', 'Yes, its polluted');
+
+      assert(!app.hasOwn('cache.polluted'));
+      assert.equal(app.cache.polluted, undefined);
+    });
+  });
 });


### PR DESCRIPTION
### 📊 Metadata *

cache-base is vulnerable to Prototype Pollution.


#### Bounty URL: https://www.huntr.dev/bounties/1-npm-cache-base

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
var cacheBase = require("cache-base")
const app = new cacheBase();
app.set('__proto__.polluted', 'Yes! Its Polluted');
console.log(app.get('polluted'));
```

Execute the following commands in terminal:

```
npm i cache-base # Install affected module
node poc.js #  Run the PoC
```

Check the Output:

`Yes! Its Polluted`

### 🔥 Proof of Fix (PoF) *

Before:

![image](https://user-images.githubusercontent.com/64132745/104119482-97db7680-5355-11eb-9a27-3ede87584d61.png)

After:

![image](https://user-images.githubusercontent.com/64132745/104119488-a6299280-5355-11eb-9df8-683b4e6be215.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/104119517-d5d89a80-5355-11eb-89bd-cee21e68b47c.png)
![image](https://user-images.githubusercontent.com/64132745/104119525-dffa9900-5355-11eb-8a35-d1136caf8697.png)
![image](https://user-images.githubusercontent.com/64132745/104119732-8e530e00-5357-11eb-82c9-c278b98563cb.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

_Provide the URL of the PR for the disclosure that this fix relates to._

https://github.com/418sec/huntr/pull/1498
